### PR TITLE
Fix: Theme switcher not working on first click

### DIFF
--- a/src/app/components/ui/theme-switcher.tsx
+++ b/src/app/components/ui/theme-switcher.tsx
@@ -6,7 +6,7 @@ import { FiSun, FiMoon } from "react-icons/fi";
 
 export function ThemeSwitcher() {
   const [mounted, setMounted] = useState(false);
-  const { theme, setTheme } = useTheme();
+  const { theme, resolvedTheme, setTheme } = useTheme();
 
   useEffect(() => {
     setMounted(true);
@@ -16,15 +16,19 @@ export function ThemeSwitcher() {
     return null;
   }
 
+  const currentTheme = resolvedTheme || theme;
+  const isDark = currentTheme === "dark";
+
   return (
     <button
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
       className="rounded-full p-2 hover:bg-box transition-colors"
+      aria-label={`Switch to ${isDark ? "light" : "dark"} mode`}
     >
-      {theme === "dark" ? (
-        <FiSun className="w-5 h-5" />
-      ) : (
+      {isDark ? (
         <FiMoon className="w-5 h-5" />
+      ) : (
+        <FiSun className="w-5 h-5" />
       )}
     </button>
   );


### PR DESCRIPTION
## Fix: Theme switcher not working on first click

### Problem
The theme switcher button had two issues:
1. **First click didn't change theme**: On the first click, the theme was saved to localStorage but the UI didn't update visually
2. **Icons were incorrect**: After the second click, the icons displayed incorrectly (showing sun when it should show moon and vice versa)

### Root Cause
The component was using `theme` from `next-themes` instead of `resolvedTheme`. Since the `ThemeProvider` has `defaultTheme="system"`, the `theme` value can be `"system"` initially, which doesn't accurately reflect the actual resolved theme (`"dark"` or `"light"`).

### Solution
- Use `resolvedTheme` to get the actual current theme state
- Created a single `isDark` variable that's used consistently for both:
  - Determining which theme to toggle to
  - Displaying the correct icon
- Added `aria-label` for better accessibility

### Changes
- Modified `src/app/components/ui/theme-switcher.tsx` to use `resolvedTheme` instead of `theme`
- Ensured icon display logic matches the toggle logic using the same `isDark` check

### Testing
- ✅ Theme now changes correctly on first click
- ✅ Icons always display correctly (moon for dark mode, sun for light mode)
- ✅ Works correctly when starting from system theme preference